### PR TITLE
Change return message in error case to be able to better debug

### DIFF
--- a/protocols/oidc.js
+++ b/protocols/oidc.js
@@ -30,7 +30,7 @@ module.exports = (SSOUtils) => {
         },
         auth: (Env, cfg, cb) => {
             getClient(cfg, (err, client) => {
-                if (err) { return void cb ('E_OIDC_CONNECT'); }
+                if (err) { return void cb (err); }
                 let username_scope = cfg.username_scope || 'profile';
                 let email_scope = cfg.email_scope || 'email'; // This is not yet used
 
@@ -51,7 +51,7 @@ module.exports = (SSOUtils) => {
         },
         authCb: (Env, cfg, token, url, cookies, cb) => {
             getClient(cfg, (err, client) => {
-                if (err) { return void cb ('E_OIDC_CONNECT'); }
+                if (err) { return void cb (err); }
 
                 const params = client.callbackParams(url);
                 delete params.state;


### PR DESCRIPTION
Hi,

trying your plugin I had a lot of trouble figuring out why it doesn't work. This commit changes the log messages in cryptpad from "E_OIDC_CONNECT" to the actual error message.

BR