### PR TITLE
scope as sent to OP must not have trailing spaces

### DIFF
--- a/protocols/oidc.js
+++ b/protocols/oidc.js
@@ -54,7 +54,7 @@ module.exports = (SSOUtils) => {
                 let extra_scope = cfg.extra_scope || ''; // This is not yet used
 
                 let config = {
-                    scope: `openid ${username_scope} ${email_scope} ${extra_scope}`,
+                    scope: `openid ${username_scope} ${email_scope} ${extra_scope}`.trim(),
                     //resource: opts.callbackURL,
                     //access_type: 'offline',
                     state: Math.random().toString(36), // Just create a state for providers that require it...


### PR DESCRIPTION
In case `email_scope` and `extra_scope` have no value this would result in trailing spaces in the `scope` field converted to `%20`. At least one OP rejects this as an invalid scope

See https://www.rfc-editor.org/rfc/rfc6749#appendix-A.4